### PR TITLE
Fix plugin scanning

### DIFF
--- a/fm.helio.Workstation.json
+++ b/fm.helio.Workstation.json
@@ -3,7 +3,7 @@
     "runtime": "org.freedesktop.Platform",
     "sdk": "org.freedesktop.Sdk",
     "runtime-version": "23.08",
-    "command": "helio",
+    "command": "/app/bin/helio",
     "rename-icon": "helio-workstation",
     "rename-desktop-file": "Helio.desktop",
     "finish-args": [
@@ -37,7 +37,7 @@
                 "install -Dm755 Projects/LinuxMakefile/build/helio -t ${FLATPAK_DEST}/bin",
                 "install -Dm644 Projects/Deployment/Linux/fm.helio.Workstation.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo",
                 "install -Dm644 Projects/Deployment/Linux/Debian/x64/usr/share/applications/Helio.desktop -t ${FLATPAK_DEST}/share/applications",
-                "desktop-file-edit --set-key=Exec --set-value=helio ${FLATPAK_DEST}/share/applications/Helio.desktop",
+                "desktop-file-edit --set-key=Exec --set-value=/app/bin/helio ${FLATPAK_DEST}/share/applications/Helio.desktop",
                 "cp -a Projects/Deployment/Linux/Debian/x64/usr/share/icons ${FLATPAK_DEST}/share/",
                 "install -d /app/extensions/Plugins"
             ],


### PR DESCRIPTION
During plugin scanning, Helio is launching itself as a child process, and due to perhaps what is a JUCE limitation, it cannot cope with being launched as `helio` (even though the `helio` binary is on `$PATH`). It seems Helio must be launched with an absolute path to the binary for plugin scanning to work.

Broken:

```
$ flatpak run --command=helio fm.helio.Workstation
Safe scanning: /app/extensions/Plugins/vst3/Dexed.vst3
JUCE Assertion failure in juce_posix_SharedCode.h:1100
Done scanning for audio plugins

$ flatpak run --devel --command=bash fm.helio.Workstation -c 'echo $PATH'
/app/bin:/usr/bin
```

Working:

```
$ flatpak run --command=/app/bin/helio fm.helio.Workstation
Safe scanning: /app/extensions/Plugins/vst3/Dexed.vst3
Done scanning for audio plugins
```

Fixes: https://github.com/flathub/fm.helio.Workstation/issues/1